### PR TITLE
Increase Pods per Node

### DIFF
--- a/CloudFormation.json
+++ b/CloudFormation.json
@@ -1426,6 +1426,94 @@
                     }
                 ]
             }
+        },
+        "VPCCNIRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "RoleName": {
+                    "Fn::Sub": "${ProjectName}-${EnvironmentName}-irsa-aws-vpc-cni"
+                },
+                "AssumeRolePolicyDocument": {
+                    "Fn::Sub": [
+                        "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [\n    {\n      \"Effect\": \"Allow\",\n      \"Principal\": {\n        \"Federated\": \"arn:aws:iam::${AWS::AccountId}:oidc-provider/${ClusterOIDCURL}\"\n      },\n      \"Action\": \"sts:AssumeRoleWithWebIdentity\",\n      \"Condition\": {\n        \"StringLike\": {\n          \"${ClusterOIDCURL}:aud\": \"sts.amazonaws.com\",\n          \"${ClusterOIDCURL}:sub\": \"system:serviceaccount:kube-system:aws-node\"\n        }\n      }\n    }\n  ]\n}\n",
+                        {
+                            "ClusterOIDCURL": {
+                                "Fn::Join": [
+                                    "",
+                                    {
+                                        "Fn::Split": [
+                                            "https://",
+                                            {
+                                                "Fn::GetAtt": [
+                                                    "EKSCluster",
+                                                    "OpenIdConnectIssuerUrl"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "ManagedPolicyArns": [
+                    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+                ],
+                "Path": "/",
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": {
+                            "Ref": "EnvironmentName"
+                        }
+                    },
+                    {
+                        "Key": "Project",
+                        "Value": {
+                            "Ref": "ProjectName"
+                        }
+                    },
+                    {
+                        "Key": "ManagedBy",
+                        "Value": "CloudFormation"
+                    }
+                ]
+            }
+        },
+        "VPCCNIAddOn": {
+            "Type": "AWS::EKS::Addon",
+            "Properties": {
+                "AddonName": "vpc-cni",
+                "ClusterName": {
+                    "Ref": "EKSCluster"
+                },
+                "ConfigurationValues": "{\"env\":{\"ENABLE_PREFIX_DELEGATION\":\"true\"}}",
+                "ResolveConflicts": "OVERWRITE",
+                "ServiceAccountRoleArn": {
+                    "Fn::GetAtt": [
+                        "VPCCNIRole",
+                        "Arn"
+                    ]
+                },
+                "Tags": [
+                    {
+                        "Key": "Environment",
+                        "Value": {
+                            "Ref": "EnvironmentName"
+                        }
+                    },
+                    {
+                        "Key": "Project",
+                        "Value": {
+                            "Ref": "ProjectName"
+                        }
+                    },
+                    {
+                        "Key": "ManagedBy",
+                        "Value": "CloudFormation"
+                    }
+                ]
+            }
         }
     }
 }

--- a/CloudFormation.yaml
+++ b/CloudFormation.yaml
@@ -748,3 +748,61 @@ Resources:
           Value: !Ref ProjectName
         - Key: ManagedBy
           Value: CloudFormation
+  VPCCNIRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: !Sub '${ProjectName}-${EnvironmentName}-irsa-aws-vpc-cni'
+      AssumeRolePolicyDocument: !Sub 
+        - |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/${ClusterOIDCURL}"
+                },
+                "Action": "sts:AssumeRoleWithWebIdentity",
+                "Condition": {
+                  "StringLike": {
+                    "${ClusterOIDCURL}:aud": "sts.amazonaws.com",
+                    "${ClusterOIDCURL}:sub": "system:serviceaccount:kube-system:aws-node"
+                  }
+                }
+              }
+            ]
+          }
+        - ClusterOIDCURL: !Join 
+            - ''
+            - !Split 
+              - 'https://'
+              - !GetAtt 
+                - EKSCluster
+                - OpenIdConnectIssuerUrl
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy'
+      Path: /
+      Tags:
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Project
+          Value: !Ref ProjectName
+        - Key: ManagedBy
+          Value: CloudFormation
+  VPCCNIAddOn:
+    Type: 'AWS::EKS::Addon'
+    Properties:
+      AddonName: vpc-cni
+      ClusterName: !Ref EKSCluster
+      ConfigurationValues: '{"env":{"ENABLE_PREFIX_DELEGATION":"true"}}'
+      ResolveConflicts: OVERWRITE
+      ServiceAccountRoleArn: !GetAtt 
+        - VPCCNIRole
+        - Arn
+      Tags:
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Project
+          Value: !Ref ProjectName
+        - Key: ManagedBy
+          Value: CloudFormation

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ There did not seem to be a complete example of deploying all required components
 - EBS CSI Add-on and associated IAM Roles for Service Accounts (IRSA) and policy
 - EFS CSI Add-on and associated IAM Roles for Service Accounts (IRSA) and policy
 - Core DNS Add-on
+- KMS Encrypted Secrets
 - Kube Proxy Add-on
+- VPC CNI Add-on and associated IAM Roles for Service Accounts (IRSA) and policy
+
 
 [When you provision a cluster, Amazon EKS installs VPC CNI automatically.](https://aws.github.io/aws-eks-best-practices/networking/vpc-cni/#deploy-vpc-cni-managed-add-on)
 
@@ -28,6 +31,8 @@ Writing the AssumeRolePolicyDocument as a [Fn::Sub](https://docs.aws.amazon.com/
 [The trick is to know that the AssumeRolePolicyDocument value in a template is specified as json. As such, we can perform a !Sub on any value we pass to it, as long as the result is a valid json string.](https://bambooengineering.io/constraining-eks-pod-iam-roles-using-cloudformation/)
 
 The [ThumbprintList for the OIDCProvider is hardcoded](https://gist.github.com/riccardomc/a3891356b09516ab3f3b79a12e9b13e1), as the certificate is valid until 06/29/2034. We can get the complete [AWS::EKS::Cluster CertificateAuthorityData](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#aws-resource-eks-cluster-return-values) but would then need to [calculate the thumbprint using OpenSSL](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html) and an external process.
+
+To achieve higher pod density, the VPC CNI plugin leverages a new VPC capability that [enables IP address prefixes](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) to be associated with elastic network interfaces (ENIs) attached to EC2 instances. Customers can now [supply their configuration directly](https://aws.amazon.com/blogs/containers/amazon-eks-add-ons-advanced-configuration/) through the Amazon EKS add-ons API, to install and configure their operational software during cluster creation in a single step. 
 
 ## EFS Dynamic Provisioning
 To create a dynamically provisioned EFS persistent volume claim:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The [ThumbprintList for the OIDCProvider is hardcoded](https://gist.github.com/r
 
 To achieve higher pod density, the VPC CNI plugin leverages a new VPC capability that [enables IP address prefixes](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/) to be associated with elastic network interfaces (ENIs) attached to EC2 instances. Customers can now [supply their configuration directly](https://aws.amazon.com/blogs/containers/amazon-eks-add-ons-advanced-configuration/) through the Amazon EKS add-ons API, to install and configure their operational software during cluster creation in a single step. 
 
+**NOTE:** The max pods value will be set on [any newly created managed node groups, or node groups updated to a newer AMI version](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/).
+
 ## EFS Dynamic Provisioning
 To create a dynamically provisioned EFS persistent volume claim:
 


### PR DESCRIPTION
Configure ENABLE_PREFIX_DELEGATION=true
https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/
https://aws.amazon.com/blogs/containers/amazon-eks-add-ons-advanced-configuration/

**NOTE:** The max pods value will be set on [any newly created managed node groups, or node groups updated to a newer AMI version](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-increases-pods-per-node-limits/).
